### PR TITLE
Base metrics

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -1,0 +1,36 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// runCmd represents the run command
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Args:  cobra.ExactArgs(1),
+	Short: "",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(args[0])
+		// Read line by line file in go
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// runCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// runCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/anthony-pei/ECE461/cli/metrics"
 	"github.com/spf13/cobra"
 )
 
@@ -16,8 +17,14 @@ var runCmd = &cobra.Command{
 	Short: "",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(args[0])
-		// Read line by line file in go
+		git_url := args[0]
+		fmt.Println(git_url)
+		g := metrics.GitHubModule{
+			Url: git_url,
+		}
+		m := metrics.LicenseMetric{}
+		m.Calculate(g)
+		// TODO: Read line by line file in go
 	},
 }
 

--- a/cli/metrics/github_module.go
+++ b/cli/metrics/github_module.go
@@ -1,0 +1,9 @@
+package metrics
+
+type github_module struct {
+	url string
+}
+
+func (g github_module) get_url() string {
+	return g.url
+}

--- a/cli/metrics/github_module.go
+++ b/cli/metrics/github_module.go
@@ -1,9 +1,9 @@
 package metrics
 
-type github_module struct {
-	url string
+type GitHubModule struct {
+	Url string
 }
 
-func (g github_module) get_url() string {
-	return g.url
+func (g GitHubModule) GetGitHubUrl() string {
+	return g.Url
 }

--- a/cli/metrics/license.go
+++ b/cli/metrics/license.go
@@ -2,11 +2,11 @@ package metrics
 
 import "fmt"
 
-type license_metric struct {
+type LicenseMetric struct {
 }
 
-func (l license_metric) calculate(m module) float64 {
+func (l LicenseMetric) Calculate(m Module) float64 {
 	// Object l of type license matrix and m of type module with function get_url()\
-	fmt.Println("Calculating license metric")
+	fmt.Println("Calculating license metric for module:", m.GetGitHubUrl())
 	return 0.0
 }

--- a/cli/metrics/license.go
+++ b/cli/metrics/license.go
@@ -1,0 +1,12 @@
+package metrics
+
+import "fmt"
+
+type license_metric struct {
+}
+
+func (l license_metric) calculate(m module) float64 {
+	// Object l of type license matrix and m of type module with function get_url()\
+	fmt.Println("Calculating license metric")
+	return 0.0
+}

--- a/cli/metrics/metric.go
+++ b/cli/metrics/metric.go
@@ -1,0 +1,9 @@
+package metrics
+
+type metric interface {
+	calculate(m module) float64
+}
+
+type module interface {
+	get_github_url() string
+}

--- a/cli/metrics/metric.go
+++ b/cli/metrics/metric.go
@@ -1,9 +1,9 @@
 package metrics
 
-type metric interface {
-	calculate(m module) float64
+type Metric interface {
+	Calculate(m Module) float64
 }
 
-type module interface {
-	get_github_url() string
+type Module interface {
+	GetGitHubUrl() string
 }


### PR DESCRIPTION
Set up base metric classes to allow for easy inheritance. Run command can create and call these sub classes.